### PR TITLE
Fix compatibility issues due to spread operator

### DIFF
--- a/src/msgdown.js
+++ b/src/msgdown.js
@@ -22,7 +22,7 @@ const defaultTokens = {
 }
 
 module.exports = (text, tokens = defaultTokens) => {
-  tokens = {...defaultTokens, ...tokens}
+  tokens = Object.assign({}, defaultTokens, tokens)
   const appendDefault = () => {
     html += text[index]
     index++


### PR DESCRIPTION
Just noticed from the issue in vue-beautiful-chat.

Even though it's valid javascript, spread operator is cutting edge as far as tooling goes so it may be worth it to address the issue.

This is a minor fix, I didn't look too deep into it, and there are probably other ways to address it.